### PR TITLE
Update ocpp-server.js to prevent node red restarts

### DIFF
--- a/ocpp/ocpp-server.js
+++ b/ocpp/ocpp-server.js
@@ -363,8 +363,8 @@ module.exports = function(RED) {
 
           ws.on('close', function(code, reason) {
             debug_csserver(`ws closed for ${eventname}, code ${code}, reason: ${reason}`);
-            // ee.removeAllListeners(connname);
-            // ee.removeAllListeners(eventname);
+            ee.removeAllListeners(connname);
+            ee.removeAllListeners(eventname);
           });
 
           ws.on('error', function(err) {
@@ -397,120 +397,124 @@ module.exports = function(RED) {
               ee.on(eventname, wsrequest);
             }
 
-            if (msgIn[0] != '[') {
-              msgParsed = JSON.parse('[' + msgIn + ']');
-            } else {
-              msgParsed = JSON.parse(msgIn);
-            }
-
-            logger.log(msgTypeStr[msgParsed[msgType] - CALL], msgIn);
-
-            msg.ocpp.MessageId = msgParsed[msgId];
-            msg.ocpp.msgType = msgParsed[msgType];
-
-            debug_csserver(`Message from: ${cbid} ${msgParsed[msgAction]}`);
-
-            if (msgParsed[msgType] == CALL) {
-              msg.msgId = id;
-              msg.ocpp.command = msgParsed[msgAction];
-              msg.payload.command = msgParsed[msgAction];
-              msg.payload.data = msgParsed[msgCallPayload];
-
-              let to = setTimeout(
-                function(id) {
-                  // node.log("kill:" + id);
-                  if (ee.listenerCount(id) > 0) {
-                    let evList = ee.listeners(id);
-                    ee.removeListener(id, evList[0]);
-                    debug_csserver(`Removed stale message id: ${id}`);
-                  }
-                },
-                60 * 1000,
-                id
-              );
-
-              callMsgIdToCmd.unshift({
-                msgId: msg.ocpp.MessageId,
-                command: msg.ocpp.command,
-              });
-
-              while (callMsgIdToCmd.length > 25) {
-                callMsgIdToCmd.pop();
+            try {
+              if (msgIn[0] != '[') {
+                msgParsed = JSON.parse('[' + msgIn + ']');
+              } else {
+                msgParsed = JSON.parse(msgIn);
               }
-              // debug_csserver({callMsgIdToCmd});
 
-              // This makes the response async so that we pass the responsibility onto the response node
-              ee.once(id, function(returnMsg) {
-                clearTimeout(to);
-                response[msgType] = CALLRESULT;
-                response[msgId] = msgParsed[msgId];
-                response[msgResPayload] = returnMsg;
+              logger.log(msgTypeStr[msgParsed[msgType] - CALL], msgIn);
 
-                logger.log(
-                  msgTypeStr[response[msgType] - CALL],
-                  JSON.stringify(response).replace(/,/g, ', ')
+              msg.ocpp.MessageId = msgParsed[msgId];
+              msg.ocpp.msgType = msgParsed[msgType];
+
+              debug_csserver(`Message from: ${cbid} ${msgParsed[msgAction]}`);
+
+              if (msgParsed[msgType] == CALL) {
+                msg.msgId = id;
+                msg.ocpp.command = msgParsed[msgAction];
+                msg.payload.command = msgParsed[msgAction];
+                msg.payload.data = msgParsed[msgCallPayload];
+
+                let to = setTimeout(
+                  function(id) {
+                    // node.log("kill:" + id);
+                    if (ee.listenerCount(id) > 0) {
+                      let evList = ee.listeners(id);
+                      ee.removeListener(id, evList[0]);
+                      debug_csserver(`Removed stale message id: ${id}`);
+                    }
+                  },
+                  60 * 1000,
+                  id
                 );
 
-                ws.send(JSON.stringify(response));
-              });
-              node.status({
-                fill: 'green',
-                shape: 'dot',
-                text: `Request: ${msg.ocpp.command}`,
-              });
+                callMsgIdToCmd.unshift({
+                  msgId: msg.ocpp.MessageId,
+                  command: msg.ocpp.command,
+                });
 
-              node.send(msg);
-            } else if (msgParsed[msgType] == CALLRESULT) {
-              msg.msgId = msgParsed[msgId];
-              msg.payload.data = msgParsed[msgResPayload];
+                while (callMsgIdToCmd.length > 25) {
+                  callMsgIdToCmd.pop();
+                }
+                // debug_csserver({callMsgIdToCmd});
 
-              // Lookup the command name via the returned message ID
-              if (reqMsgIdToCmd[msg.msgId]) {
-                msg.ocpp.command = reqMsgIdToCmd[msg.msgId];
-                delete reqMsgIdToCmd[msg.msgId];
-              } else {
-                msg.ocpp.command = 'unknown';
+                // This makes the response async so that we pass the responsibility onto the response node
+                ee.once(id, function(returnMsg) {
+                  clearTimeout(to);
+                  response[msgType] = CALLRESULT;
+                  response[msgId] = msgParsed[msgId];
+                  response[msgResPayload] = returnMsg;
+
+                  logger.log(
+                    msgTypeStr[response[msgType] - CALL],
+                    JSON.stringify(response).replace(/,/g, ', ')
+                  );
+
+                  ws.send(JSON.stringify(response));
+                });
+                node.status({
+                  fill: 'green',
+                  shape: 'dot',
+                  text: `Request: ${msg.ocpp.command}`,
+                });
+
+                node.send(msg);
+              } else if (msgParsed[msgType] == CALLRESULT) {
+                msg.msgId = msgParsed[msgId];
+                msg.payload.data = msgParsed[msgResPayload];
+
+                // Lookup the command name via the returned message ID
+                if (reqMsgIdToCmd[msg.msgId]) {
+                  msg.ocpp.command = reqMsgIdToCmd[msg.msgId];
+                  delete reqMsgIdToCmd[msg.msgId];
+                } else {
+                  msg.ocpp.command = 'unknown';
+                }
+                node.status({
+                  fill: 'blue',
+                  shape: 'dot',
+                  text: `Result: ${msg.ocpp.command}`,
+                });
+
+                ee.emit(msg.msgId, msg);
+              } else if (msgParsed[msgType] == CALLERROR) {
+                msg.payload.ErrorCode = msgParsed[2];
+                msg.payload.ErrorDescription = msgParsed[3];
+                msg.payload.ErrorDetails = msgParsed[4];
+
+                // search the command array for the command associated with the message id
+
+                let findMsgId = { msgId: msg.ocpp.MessageId };
+
+                let cmdIdx = callMsgIdToCmd.findIndex(getCmdIdx, findMsgId);
+
+                if (cmdIdx != -1) {
+                  msg.payload.command = callMsgIdToCmd[cmdIdx].command;
+                  msg.ocpp.command = msg.payload.command;
+                  delete callMsgIdToCmd.splice(cmdIdx, 1);
+                } else {
+                  msg.payload.command = 'unknown';
+                  msg.ocpp.command = msg.payload.command;
+                }
+
+                node.status({
+                  fill: 'red',
+                  shape: 'dot',
+                  text: `ERROR: ${msg.payload.command}`,
+                });
+
+                debug_csserver(`Got an ERROR: ${msg}`);
+
+                node.send(msg);
               }
-              node.status({
-                fill: 'blue',
-                shape: 'dot',
-                text: `Result: ${msg.ocpp.command}`,
-              });
 
-              ee.emit(msg.msgId, msg);
-            } else if (msgParsed[msgType] == CALLERROR) {
-              msg.payload.ErrorCode = msgParsed[2];
-              msg.payload.ErrorDescription = msgParsed[3];
-              msg.payload.ErrorDetails = msgParsed[4];
-
-              // search the command array for the command associated with the message id
-
-              let findMsgId = { msgId: msg.ocpp.MessageId };
-
-              let cmdIdx = callMsgIdToCmd.findIndex(getCmdIdx, findMsgId);
-
-              if (cmdIdx != -1) {
-                msg.payload.command = callMsgIdToCmd[cmdIdx].command;
-                msg.ocpp.command = msg.payload.command;
-                delete callMsgIdToCmd.splice(cmdIdx, 1);
-              } else {
-                msg.payload.command = 'unknown';
-                msg.ocpp.command = msg.payload.command;
-              }
-
-              node.status({
-                fill: 'red',
-                shape: 'dot',
-                text: `ERROR: ${msg.payload.command}`,
-              });
-
-              debug_csserver(`Got an ERROR: ${msg}`);
-
-              node.send(msg);
-            }
-
-            function getCmdIdx(cmds) {
-              return cmds.msgId === this.msgId;
+              function getCmdIdx(cmds) {
+                return cmds.msgId === this.msgId;
+              } 
+            } catch (err) {
+              logger.log("ERROR", err.message);
             }
           });
 


### PR DESCRIPTION
This change worked well in versions 1.1 and 1.2 of node-red-contrib-ocpp, i had node red crash again with the update to 1.3
The uncaught exception when unexpected data is received leads to constant restarts of node red and eventually to required reboot when node red fails to restart after a few day of constant crashes. The wallbox is a Vestel EVC04 with the latest firmware (as far as customer support tells me).

Add try/catch to prevent 
SyntaxError: Unexpected token <various like \n or ]> in JSON at position ??? leading to restart of nodered every few hours.
Always expect faulty data
