### PR TITLE
msgId fix and websocket status on server

### DIFF
--- a/ocpp/ocpp-server.js
+++ b/ocpp/ocpp-server.js
@@ -337,7 +337,7 @@ module.exports = function(RED) {
             let request = [];
 
             request[msgType] = CALL;
-            request[msgId] = data.payload.MessageId || crypto.randomUUID();
+            request[msgId] = data.msgId || crypto.randomUUID();
             request[msgAction] = data.ocpp.command;
             request[msgCallPayload] = data.ocpp.data || {};
 

--- a/ocpp/ocpp-server.js
+++ b/ocpp/ocpp-server.js
@@ -367,6 +367,17 @@ module.exports = function(RED) {
             );
             ee.removeAllListeners(connname);
             ee.removeAllListeners(eventname);
+
+            msg = {
+              ocpp : {
+                websocket : 'OFFLINE',
+                chargeBoxIdentity : localcbid,
+                code : code,
+                reason : reason,                
+              }
+            };        
+            
+            node.send(msg);
           });
 
           ws.on('error', function(err) {
@@ -379,6 +390,14 @@ module.exports = function(RED) {
 
           debug_csserver(`Websocket connection to : ${localcbid}`);
 
+          msg = {
+            ocpp : {
+              websocket : 'ONLINE',
+              chargeBoxIdentity : localcbid
+            }
+          };
+          node.send(msg);
+          
           ws.on('message', function(msgIn) {
             let response = [];
 


### PR DESCRIPTION
MessageId is generated always. This fixes if you want to set msgID.  Please see the code block below.

Line 1147: node-red-contrib-ocpp/ocpp/ocpp-server.js
```
      if (msg.payload.MessageId) {
        msg.msgId = msg.payload.MessageId;
      }

      msg.payload = {};
```

Also documentation says MessageID. There is a typo there. I am not sure where to fix it.
