### PR TITLE
Enable the SyncEV chargepoint to work.

### DIFF
--- a/ocpp/ocpp-server.js
+++ b/ocpp/ocpp-server.js
@@ -386,6 +386,9 @@ module.exports = function(RED) {
 
             let msgParsed;
 
+            // Ensure msgIn is treated as a string not a buffer
+            msgIn = '' + msgIn;
+
             msg.ocpp = {};
             msg.payload = {};
 


### PR DESCRIPTION
I had to make a small change to allow this plugin to work with a SyncEV CP (EVCP-7KW-SIPH32A).
The data received from the WS was being treated as a Buffer and the parsing in ocpp-server.js was failing.

console.log(msgId) before:
<Buffer 5b 32 2c 22 78 2b 39 43 69 43 74 70 6b 6d 54 6d 32 52 67 4c 37 4b 57 6f 53 6a 55 39 47 74 38 59 35 34 5a 41 6c 32 53 71 22 2c 22 48 65 61 72 74 62 65 ... 7 more bytes>

after:
[2,"x+9CiCtpkmTm2RgL7KWoSjU9Gt8Y54ZAl2Sq","Heartbeat",{}]

cs.log before:
5/6/2023, 11:31:20 AM    node: CS        type: undefined         data: <no data>
after:
5/6/2023, 11:33:20 AM    node: CS        type: received          data: [2,"x+9CiCtpkmTm2RgL7KWoSjU9Gt8Y54ZAl2Sq","Heartbeat",{}]