### PR TITLE
added wsnoreconn in close to avoid reconnect

### DIFF
--- a/ocpp/ocpp-cp-json.js
+++ b/ocpp/ocpp-cp-json.js
@@ -457,6 +457,7 @@ module.exports = function(RED) {
         node.send(msg);//send update
         NetStatus = msg.ocpp.websocket;
       }
+      wsnoreconn = true;
       ws.close();
     });
 


### PR DESCRIPTION
While using the CP client JSON I've seen that when deploying changes to the flow, the 'close' function is called which closes the websocket. However when the websocket is closed, the wsClose function starts a timer to reconnect the websocket after the configured delay. So having multiple connections open after a few deploys. I've added the already exisiting wsnoreconn to avoid this.
I did not notice this behaviour when using the CS server. However I got connection problems with my CPO and also with the publicly available test server ws://ws.ocpp-css.com/ocpp (https://github.com/apostoldevel/ocpp-cs).
I think this might also solve issue #50 