### PR TITLE
fix: clarify 'Delay connection on startup' option and fix label typo (#74)

### DIFF
--- a/ocpp/ocpp-cp-json.html
+++ b/ocpp/ocpp-cp-json.html
@@ -92,7 +92,7 @@
     </div>
     <div class="form-row">
         <input type="checkbox" id="node-input-wsdelayconnect" value="" style="display: inline-block; width: auto; vertical-align: top; margin-left: 30px; margin-right: 5px;">
-        <label for="node-input-wsdealyconnect" style="width: auto" >Delay connection on startup </label>
+        <label for="node-input-wsdelayconnect" style="width: auto" >Delay auto-connect on startup </label>
     </div>
     <div class="form-row">
         <label for="node-input-command"><i class="icon-cog"></i> Command</label>
@@ -157,8 +157,8 @@
         <dd>The URL of the Central System this charge point communicates with</dd>
         <dt>OCPP Ver</dt>
         <dd><i>*Future use<br/>Currently defaults to OCPP JSON 1.6 only</i></dd>
-        <dt>Delay connection on startup</dt>
-        <dd>If checked the websocket connection to the CS (CSMS) is not immediately attempted when the flow is started. Instead a message type "99" and command of "connect" must be sent to the node to initiate a connection</dd>
+        <dt>Delay auto-connect on startup</dt>
+        <dd>If checked, the websocket connection to the CS (CSMS) is not immediately attempted when the flow is started. Instead, a message with type "99" and command "connect" must be sent to the node to initiate a connection. If unchecked (default), the node auto-connects to the CSMS as soon as the flow starts.</dd>
         <dt>Command:</i></dt>
         <dd>(Optional) Select an OCPP command to send if none is passed in via <code>msg.payload.command</code></dd>
         <dt>Command Params:</dt>

--- a/ocpp/ocpp-cp-json.js
+++ b/ocpp/ocpp-cp-json.js
@@ -306,9 +306,8 @@ module.exports = function(RED) {
       }
     };
 
-    // Only do this if auto-connect is enabled
-    //
-    if (!(node.delay_auto_connect) && csmsURL){
+    // Auto-connect on startup unless "Delay auto-connect on startup" is checked
+    if (!node.delay_auto_connect && csmsURL){
       node.status({fill: 'blue', shape: 'dot', text: `Connecting...`});
       wsConnect();
     }


### PR DESCRIPTION
## Summary

Addresses the confusion reported in #74 where the "Delay connection on startup" checkbox was misleading.

### Changes

1. **Fix `for` attribute typo** — The `<label>` had `for="node-input-wsdealyconnect"` (note the `eal` instead of `ela`), so clicking the label text didn't toggle the checkbox. Fixed to `for="node-input-wsdelayconnect"`.

2. **Rename option** — Changed from "Delay connection on startup" to "Delay auto-connect on startup" to make it clearer that this controls whether the node auto-connects, not some timeout delay.

3. **Clarify documentation** — Updated the help text to explicitly describe both checked and unchecked behavior:
   - Checked: connection is deferred until a type "99" connect message is sent
   - Unchecked (default): node auto-connects to the CSMS on flow start

4. **Clarify inline comment** in JS to match the renamed label.

### Notes

- No functional/logic changes — the auto-connect behavior is unchanged
- The config key `wsdelayconnect` is preserved for backward compatibility
- Existing flows will work without modification

Fixes #74